### PR TITLE
fix the example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ export default class MyComponent extends Component {
   @reads('postName.result') theNameOfThePost;
   
   postName() {
-    const promise = new Promise(async (resolve /*, reject */) => {
+    const promise = (async function() {
       const record = await this.store.findRecord('post', this.someId);
 
       resolve(record.name);
-    });
+    })();
 
     return new PromiseMonitor(promise);
   }


### PR DESCRIPTION
This was the explicit promise construction antipattern and was swallowing errors. There are a few ways how to solve this:
- using an IIFE (this fix)
- using `.then(async function(data){ `
- using `Promise.resolve().then(async function() {`
- using `then` over async/await
I think however this PR introduces the version closest to the original.